### PR TITLE
Precalculate inverse to speed up division and normalisation

### DIFF
--- a/src/crystaledge/vector2.cr
+++ b/src/crystaledge/vector2.cr
@@ -87,7 +87,8 @@ module CrystalEdge
 
     # Performs division
     def /(other : Float64)
-      Vector2.new(self.x/other, self.y/other)
+      # Multiply by the inverse => only do 1 division instead of 3
+      self * (1.0 / other)
     end
 
     # Clones this vector and passes it into a block if given
@@ -105,8 +106,9 @@ module CrystalEdge
     def normalize!
       m = magnitude
       unless m == 0
-        self.x /= m
-        self.y /= m
+        inverse = 1.0 / m
+        self.x *= inverse
+        self.y *= inverse
       end
       self
     end

--- a/src/crystaledge/vector3.cr
+++ b/src/crystaledge/vector3.cr
@@ -79,7 +79,8 @@ module CrystalEdge
     end
 
     def /(other : Float64)
-      Vector3.new(self.x/other, self.y/other, self.z/other)
+      # Multiply by the inverse => only do 1 division instead of 3
+      self * (1.0 / other)
     end
 
     def clone
@@ -95,9 +96,10 @@ module CrystalEdge
     def normalize!
       m = magnitude
       unless m == 0
-        self.x /= m
-        self.y /= m
-        self.z /= m
+        inverse = 1.0 / m
+        self.x *= inverse
+        self.y *= inverse
+        self.z *= inverse
       end
       self
     end

--- a/src/crystaledge/vector4.cr
+++ b/src/crystaledge/vector4.cr
@@ -77,7 +77,8 @@ module CrystalEdge
     end
 
     def /(other : Float64)
-      Vector4.new(self.x/other, self.y/other, self.z/other, self.w/other)
+      # Multiply by the inverse => only do 1 division instead of 3
+      self * (1.0 / other)
     end
 
     def clone
@@ -91,10 +92,11 @@ module CrystalEdge
     def normalize!
       m = magnitude
       unless m == 0
-        self.x /= m
-        self.y /= m
-        self.z /= m
-        self.w /= m
+        inverse = 1.0 / m
+        self.x *= inverse
+        self.y *= inverse
+        self.z *= inverse
+        self.w *= inverse
       end
       self
     end


### PR DESCRIPTION
Hi,

I found a small tweak to improve the performance of your code:

Divisions are (usually) around 5 times slower than a multiplications.
If we calculate the inverse first an then multiply by it,
the `VectorN./(other : Float64)`
and `VectorN.normalize!` functions gets a little bit faster.

In the first case
the increase in speed is not that great
because it takes much longer to create a new vector object
that do to the actual calculations.

`VectorN.normalize!` should be between 30% (Vector4) and 10% (Vector2) faster.

Here is the benchmark code I used: [benchmark.cr](https://gist.github.com/l3kn/5bbdd858b328ec603ceb0d5d56f8cc59)

The above code might look a bit strange because I am patching the Vector classes
to include the old implementations of the `normalize!` method
in order to compare it with the new one,
and instead of creating a new, "unnormalized" vector each time,
I just manipulate the values of an existing vector
(because creating new objects of a class is so slow that it would bias the benchmark).
