### PR TITLE
Implement a readable matrix representation

### DIFF
--- a/src/crystaledge/matrix.cr
+++ b/src/crystaledge/matrix.cr
@@ -298,12 +298,30 @@ module CrystalEdge
 
       # Return string representation of the matrix
       def to_s
-        W.times do |col|
-          col_str = "| "
-          H.times do |row|
-            col_str += "#{mat[index(row, col)]} "
+        # Format matrix by taking longest number
+        longer = 0
+        W.times do |row|
+          H.times do |col|
+            if longer < "#{@matrix[index(row, col)]}  ".size
+              longer = "#{@matrix[index(row, col)]}  ".size
+            end
           end
-          col_str += "\n |"
+        end
+        # Printing matrix
+        W.times do |row|
+          str = "| "
+          H.times do |col|
+            if col != H-1
+              str += "#{@matrix[index(row, col)]}  "
+            else
+              str += "#{@matrix[index(row, col)]}"
+            end            
+            (longer - "#{@matrix[index(row, col)]}  ".size).times do
+              str += " "
+            end
+          end
+          str += " |"
+          puts str
         end
       end
     {% end %}

--- a/src/crystaledge/matrix.cr
+++ b/src/crystaledge/matrix.cr
@@ -168,7 +168,7 @@ module CrystalEdge
         h.times do |c|
           cell = T.new 0
           width.times do |o|
-            cell += self[o,c] * other[r, o]
+            cell += self[o, c] * other[r, o]
           end
           result[r, c] = cell
         end
@@ -294,6 +294,17 @@ module CrystalEdge
       # Changes the value of current matrix.
       def {{key}}!(*values)
         copy_from {{key}}(*values)
+      end
+
+      # Return string representation of the matrix
+      def to_s
+        W.times do |col|
+          col_str = "| "
+          H.times do |row|
+            col_str += "#{mat[index(row, col)]} "
+          end
+          col_str += "\n |"
+        end
       end
     {% end %}
   end

--- a/src/crystaledge/matrix.cr
+++ b/src/crystaledge/matrix.cr
@@ -321,7 +321,7 @@ module CrystalEdge
             end
           end
           str += " |"
-          puts str
+          return str
         end
       end
     {% end %}


### PR DESCRIPTION
I've just notice that the Matrix class didn't have a to_s method.

It's a simple implementation that output a string under this format :
![Matrix representation](https://user-images.githubusercontent.com/29803428/57870324-23aaa180-7807-11e9-9269-a12cac993274.png)

Hope you enjoy !